### PR TITLE
Start app hidden and wait for rendering

### DIFF
--- a/main.js
+++ b/main.js
@@ -19,7 +19,7 @@ function createWindow () {
       // width: 800,
       // height: 600,
       fullscreen: true,
-      backgroundColor: '#000000'
+      backgroundColor: '#3e3e45'
   })
 
   // Disables F11 (Fullscreen switch)

--- a/main.js
+++ b/main.js
@@ -14,11 +14,11 @@ let mainWindow
 function createWindow () {
   // Create the browser window.
   mainWindow = new BrowserWindow({
+      show: false,
       frame: false,
       //radii: [5,5,5,5], //rounded corners
       // width: 800,
       // height: 600,
-      fullscreen: true,
       backgroundColor: '#3e3e45'
   })
 
@@ -31,6 +31,11 @@ function createWindow () {
     protocol: 'file:',
     slashes: true
   }))
+
+  mainWindow.once('ready-to-show', () => {
+    mainWindow.setFullScreen(true)
+    mainWindow.show()
+  })
 
   // Open the DevTools.
   // mainWindow.webContents.openDevTools()


### PR DESCRIPTION
This should fix most noticeable flickering. There is still very quick change in background color to gradient. I think it happens because of re-render at switching to fullscreen. 
It should be completely fixed after dealing with fullscreen without window manager, since app will be launched at native resolution and switch to fullscreen mode will be unnecessary. 