### PR TITLE
Start app at primary display resolution

### DIFF
--- a/main.js
+++ b/main.js
@@ -21,6 +21,7 @@ function createWindow () {
   // Create the browser window.
   mainWindow = new BrowserWindow({
       show: false,
+      resizable: false,
       frame: false,
       //radii: [5,5,5,5], //rounded corners
       width: displayWidth,

--- a/main.js
+++ b/main.js
@@ -12,13 +12,19 @@ const url = require('url')
 let mainWindow
 
 function createWindow () {
+  // Window size must set explicitly when running without window manager
+  const screen = electron.screen;
+  const primaryDisplay = screen.getPrimaryDisplay();
+  const displayWidth = primaryDisplay.size.width;
+  const displayHeight = primaryDisplay.size.height;
+
   // Create the browser window.
   mainWindow = new BrowserWindow({
       show: false,
       frame: false,
       //radii: [5,5,5,5], //rounded corners
-      // width: 800,
-      // height: 600,
+      width: displayWidth,
+      height: displayHeight,
       backgroundColor: '#3e3e45'
   })
 


### PR DESCRIPTION
Start app at primary display resolution, but not in fullscreen mode to prevent flickering. 